### PR TITLE
change region all to iad1

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "regions": [
-    "all"
+    "iad1"
   ],
   "functions": {
     "api/**": {


### PR DESCRIPTION
Reference: https://vercel.com/support/articles/choosing-deployment-regions

```
For Hobby accounts, the default deployment region for Serverless Functions of IAD1 cannot be changed. As a result, it is recommended to locate your data source as close to this region as possible.
```